### PR TITLE
Remove OpenSSL dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: 1.65
+rust: 1.66
 cache: cargo
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 0.2.0
+- Remove OpenSSL dependency.
+
 # 0.1.0
 - Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mauth-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,16 +10,16 @@ anyhow = "1"
 base64 = "0.13"
 hex = "0.4"
 lazy-regex = "2"
-openssl = "0.10"
+rsa = "0.7"
 regex = { version = "1", default_features = false, features = ["std"] }
-sha2 = "0.9"
+sha2 = { version = "0.10", features = ["oid"] }
 urlencoding = "2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 criterion = "0.4"
-rstest = "0.15.0"
+rstest = "0.15"
 
 [[bench]]
 name = "benchmark"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,15 +1,14 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use mauth_core::signer::Signer;
 use mauth_core::verifier::Verifier;
-use openssl::rsa::Rsa;
 
 const APP_UUID: &str = "8ac278af-e761-479b-9e7a-10bcc2f30304";
 const TIMESTAMP: &str = "1669858655";
 const QS: &str = "don=quixote&quixote=don";
 
 fn bench_signer(c: &mut Criterion) {
-    let rsa = Rsa::generate(2048).unwrap();
-    let private_key = String::from_utf8(rsa.private_key_to_pem().unwrap()).unwrap();
+    let private_key =
+        std::fs::read_to_string("tests/mauth-protocol-test-suite/signing-params/rsa-key").unwrap();
     let signer = Signer::new(APP_UUID, private_key).unwrap();
 
     let short_body = "Somewhere in La Mancha, in a place I do not care to remember".as_bytes();
@@ -50,9 +49,11 @@ fn bench_signer(c: &mut Criterion) {
 }
 
 fn bench_verifier(c: &mut Criterion) {
-    let rsa = Rsa::generate(2048).unwrap();
-    let private_key = String::from_utf8(rsa.private_key_to_pem().unwrap()).unwrap();
-    let public_key = String::from_utf8(rsa.public_key_to_pem().unwrap()).unwrap();
+    let private_key =
+        std::fs::read_to_string("tests/mauth-protocol-test-suite/signing-params/rsa-key").unwrap();
+    let public_key =
+        std::fs::read_to_string("tests/mauth-protocol-test-suite/signing-params/rsa-key-pub")
+            .unwrap();
     let signer = Signer::new(APP_UUID, private_key).unwrap();
     let verifier = Verifier::new(APP_UUID, public_key).unwrap();
 


### PR DESCRIPTION
OpenSSL dependency will cause issues when building binaries for musl on Linux:
- https://github.com/sfackler/rust-openssl/issues/603 
- https://github.com/mdsol/hammertime-rust/pull/18#discussion_r1055075114

Replacing OpenSSL with [pure Rust crypto](https://github.com/RustCrypto?type=source)

This change will degrade performance (OpenSSL's performance is great) but I believe there are more advantages than disadvantages.

@mdsol/architecture-enablement @masongup-mdsol @ashajpaul 