### PR TITLE
Convert from anyhow to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["security", "authentication"]
 categories = ["authentication"]
 
 [dependencies]
-anyhow = "1"
+thiserror = "1"
 base64 = "0.22"
 hex = "0.4"
 lazy-regex = "3"
@@ -20,6 +20,7 @@ rsa = "0.9.0"
 regex = { version = "1", default_features = false, features = ["std"] }
 sha2 = { version = "0.10", features = ["oid"] }
 urlencoding = "2"
+spki = "0.7"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,27 @@
 use thiserror::Error;
 
+/// All of the possible errors that can happen while performing mauth operations
 #[derive(Debug, Error)]
-pub enum MAuthError {
+pub enum Error {
+    /// A UTF8 decode error while attempting to process the URL
     #[error("Unable to handle the URL as the format was invalid: {0}")]
-    UrlFormatError(#[from] std::string::FromUtf8Error),
+    UrlEncodingError(#[from] std::string::FromUtf8Error),
+    /// A MAuth version that is not supported was requested
     #[error("Version {0} is not supported")]
     UnsupportedVersion(u8),
+    /// The provided private key could not be parsed
     #[error("Unable to parse RSA private key: {0}")]
     PrivateKeyDecodeError(#[from] rsa::pkcs1::Error),
+    /// The provided public key could not be parsed
     #[error("Unable to parse RSA public key: {0}")]
     PublicKeyDecodeError(#[from] spki::Error),
+    /// An algorithm failure occurred while trying to sign a request
     #[error("RSA algorithm error: {0}")]
     RsaSignError(#[from] rsa::Error),
+    /// An algorithm failure occurred while trying to verify a request
     #[error("Unable to verify RSA signature: {0}")]
     SignatureVerifyError(#[from] rsa::signature::Error),
+    /// A base64 error was encountered while attempting to verify a v1 signature
     #[error("Unable to decode base64-encoded signature: {0}")]
     SignatureDecodeError(#[from] base64::DecodeError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-pub mod mauth_error;
+/// Error types
+pub mod error;
 pub(crate) mod signable;
+/// Signing for outgoing requests
 pub mod signer;
+/// Signature verification for incoming requests
 pub mod verifier;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
-pub mod signable;
+pub mod mauth_error;
+pub(crate) mod signable;
 pub mod signer;
 pub mod verifier;

--- a/src/mauth_error.rs
+++ b/src/mauth_error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MAuthError {
+    #[error("Unable to handle the URL as the format was invalid: {0}")]
+    UrlFormatError(#[from] std::string::FromUtf8Error),
+    #[error("Version {0} is not supported")]
+    UnsupportedVersion(u8),
+    #[error("Unable to parse RSA private key: {0}")]
+    PrivateKeyDecodeError(#[from] rsa::pkcs1::Error),
+    #[error("Unable to parse RSA public key: {0}")]
+    PublicKeyDecodeError(#[from] spki::Error),
+    #[error("RSA algorithm error: {0}")]
+    RsaSignError(#[from] rsa::Error),
+    #[error("Unable to verify RSA signature: {0}")]
+    SignatureVerifyError(#[from] rsa::signature::Error),
+    #[error("Unable to decode base64-encoded signature: {0}")]
+    SignatureDecodeError(#[from] base64::DecodeError),
+}

--- a/src/signable.rs
+++ b/src/signable.rs
@@ -1,4 +1,4 @@
-use crate::mauth_error::MAuthError;
+use crate::error::Error;
 use lazy_regex::*;
 use regex::{Captures, Regex};
 use sha2::{Digest, Sha512};
@@ -38,7 +38,7 @@ impl<'a> Signable<'a> {
         }
     }
 
-    pub fn signing_string_v1(&self) -> Result<Vec<u8>, MAuthError> {
+    pub fn signing_string_v1(&self) -> Result<Vec<u8>, Error> {
         let mut hasher = Sha512::default();
 
         hasher.update(&self.verb);
@@ -54,7 +54,7 @@ impl<'a> Signable<'a> {
         Ok(hex::encode(hasher.finalize()).into_bytes())
     }
 
-    pub fn signing_string_v2(&self) -> Result<Vec<u8>, MAuthError> {
+    pub fn signing_string_v2(&self) -> Result<Vec<u8>, Error> {
         let encoded_query: String = Self::encode_query(&self.query)?;
         let body_digest = hex::encode(Sha512::digest(self.body));
 
@@ -70,14 +70,14 @@ impl<'a> Signable<'a> {
         .into_bytes())
     }
 
-    fn encode_query(qstr: &str) -> Result<String, MAuthError> {
+    fn encode_query(qstr: &str) -> Result<String, Error> {
         if qstr.is_empty() {
             return Ok("".to_string());
         }
         let mut temp_param_list = qstr
             .split('&')
             .map(Self::split_equal_and_decode)
-            .collect::<Result<Vec<[String; 2]>, MAuthError>>()?;
+            .collect::<Result<Vec<[String; 2]>, Error>>()?;
 
         temp_param_list.sort();
 
@@ -109,7 +109,7 @@ impl<'a> Signable<'a> {
         }
     }
 
-    fn split_equal_and_decode(value: &str) -> Result<[String; 2], MAuthError> {
+    fn split_equal_and_decode(value: &str) -> Result<[String; 2], Error> {
         let (k, v) = value.split_once('=').unwrap_or((value, ""));
         Ok([
             Self::replace_plus_and_decode(k)?,
@@ -117,7 +117,7 @@ impl<'a> Signable<'a> {
         ])
     }
 
-    fn replace_plus_and_decode(value: &str) -> Result<String, MAuthError> {
+    fn replace_plus_and_decode(value: &str) -> Result<String, Error> {
         Ok(decode(&value.replace('+', " "))?.into_owned())
     }
 }

--- a/src/signable.rs
+++ b/src/signable.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::mauth_error::MAuthError;
 use lazy_regex::*;
 use regex::{Captures, Regex};
 use sha2::{Digest, Sha512};
@@ -38,7 +38,7 @@ impl<'a> Signable<'a> {
         }
     }
 
-    pub fn signing_string_v1(&self) -> Result<Vec<u8>> {
+    pub fn signing_string_v1(&self) -> Result<Vec<u8>, MAuthError> {
         let mut hasher = Sha512::default();
 
         hasher.update(&self.verb);
@@ -54,7 +54,7 @@ impl<'a> Signable<'a> {
         Ok(hex::encode(hasher.finalize()).into_bytes())
     }
 
-    pub fn signing_string_v2(&self) -> Result<Vec<u8>> {
+    pub fn signing_string_v2(&self) -> Result<Vec<u8>, MAuthError> {
         let encoded_query: String = Self::encode_query(&self.query)?;
         let body_digest = hex::encode(Sha512::digest(self.body));
 
@@ -70,14 +70,14 @@ impl<'a> Signable<'a> {
         .into_bytes())
     }
 
-    fn encode_query(qstr: &str) -> Result<String> {
+    fn encode_query(qstr: &str) -> Result<String, MAuthError> {
         if qstr.is_empty() {
             return Ok("".to_string());
         }
         let mut temp_param_list = qstr
             .split('&')
             .map(Self::split_equal_and_decode)
-            .collect::<Result<Vec<[String; 2]>>>()?;
+            .collect::<Result<Vec<[String; 2]>, MAuthError>>()?;
 
         temp_param_list.sort();
 
@@ -109,7 +109,7 @@ impl<'a> Signable<'a> {
         }
     }
 
-    fn split_equal_and_decode(value: &str) -> Result<[String; 2]> {
+    fn split_equal_and_decode(value: &str) -> Result<[String; 2], MAuthError> {
         let (k, v) = value.split_once('=').unwrap_or((value, ""));
         Ok([
             Self::replace_plus_and_decode(k)?,
@@ -117,7 +117,7 @@ impl<'a> Signable<'a> {
         ])
     }
 
-    fn replace_plus_and_decode(value: &str) -> Result<String> {
+    fn replace_plus_and_decode(value: &str) -> Result<String, MAuthError> {
         Ok(decode(&value.replace('+', " "))?.into_owned())
     }
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,4 +1,4 @@
-use crate::{mauth_error::MAuthError, signable::Signable};
+use crate::{error::Error, signable::Signable};
 use base64::{engine::general_purpose, Engine as _};
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::RsaPrivateKey;
@@ -12,7 +12,7 @@ pub struct Signer {
 }
 
 impl Signer {
-    pub fn new(app_uuid: impl Into<String>, private_key_data: String) -> Result<Self, MAuthError> {
+    pub fn new(app_uuid: impl Into<String>, private_key_data: String) -> Result<Self, Error> {
         let private_key = RsaPrivateKey::from_pkcs1_pem(&private_key_data)?;
         let signing_key = rsa::pkcs1v15::SigningKey::<Sha512>::new(private_key.to_owned());
 
@@ -31,17 +31,17 @@ impl Signer {
         query: impl Into<String>,
         body: &[u8],
         timestamp: impl Into<String>,
-    ) -> Result<String, MAuthError> {
+    ) -> Result<String, Error> {
         let signable = Signable::new(verb, path, query, body, timestamp, &self.app_uuid);
 
         match version {
             1 => self.sign_string_v1(&signable),
             2 => self.sign_string_v2(&signable),
-            v => Err(MAuthError::UnsupportedVersion(v)),
+            v => Err(Error::UnsupportedVersion(v)),
         }
     }
 
-    fn sign_string_v1(&self, signable: &Signable) -> Result<String, MAuthError> {
+    fn sign_string_v1(&self, signable: &Signable) -> Result<String, Error> {
         let signature = self.private_key.sign(
             rsa::Pkcs1v15Sign::new_unprefixed(),
             &signable.signing_string_v1()?,
@@ -49,7 +49,7 @@ impl Signer {
         Ok(general_purpose::STANDARD.encode(signature))
     }
 
-    fn sign_string_v2(&self, signable: &Signable) -> Result<String, MAuthError> {
+    fn sign_string_v2(&self, signable: &Signable) -> Result<String, Error> {
         use rsa::signature::{SignatureEncoding, Signer};
 
         let sign = self.signing_key.sign(&signable.signing_string_v2()?);

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,5 +1,4 @@
-use crate::signable::Signable;
-use anyhow::{bail, Result};
+use crate::{mauth_error::MAuthError, signable::Signable};
 use base64::{engine::general_purpose, Engine as _};
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::RsaPrivateKey;
@@ -13,7 +12,7 @@ pub struct Signer {
 }
 
 impl Signer {
-    pub fn new(app_uuid: impl Into<String>, private_key_data: String) -> Result<Self> {
+    pub fn new(app_uuid: impl Into<String>, private_key_data: String) -> Result<Self, MAuthError> {
         let private_key = RsaPrivateKey::from_pkcs1_pem(&private_key_data)?;
         let signing_key = rsa::pkcs1v15::SigningKey::<Sha512>::new(private_key.to_owned());
 
@@ -32,17 +31,17 @@ impl Signer {
         query: impl Into<String>,
         body: &[u8],
         timestamp: impl Into<String>,
-    ) -> Result<String> {
+    ) -> Result<String, MAuthError> {
         let signable = Signable::new(verb, path, query, body, timestamp, &self.app_uuid);
 
         match version {
             1 => self.sign_string_v1(&signable),
             2 => self.sign_string_v2(&signable),
-            _ => bail!("Version {version} is not supported."),
+            v => Err(MAuthError::UnsupportedVersion(v)),
         }
     }
 
-    fn sign_string_v1(&self, signable: &Signable) -> Result<String> {
+    fn sign_string_v1(&self, signable: &Signable) -> Result<String, MAuthError> {
         let signature = self.private_key.sign(
             rsa::Pkcs1v15Sign::new_unprefixed(),
             &signable.signing_string_v1()?,
@@ -50,7 +49,7 @@ impl Signer {
         Ok(general_purpose::STANDARD.encode(signature))
     }
 
-    fn sign_string_v2(&self, signable: &Signable) -> Result<String> {
+    fn sign_string_v2(&self, signable: &Signable) -> Result<String, MAuthError> {
         use rsa::signature::{SignatureEncoding, Signer};
 
         let sign = self.signing_key.sign(&signable.signing_string_v2()?);

--- a/tests/protocol_test_suite.rs
+++ b/tests/protocol_test_suite.rs
@@ -88,15 +88,9 @@ fn test_verifier(
         _ => vec![],
     };
 
-    let result = verifier
+    verifier
         .verify_signature(version, req.verb, path, query, &body_data, timestamp, sig)
-        .unwrap();
-
-    if result {
-        Ok(())
-    } else {
-        Err(format!("[{test_case}] failed"))
-    }
+        .map_err(|_| format!("[{test_case}] failed"))
 }
 
 #[test]


### PR DESCRIPTION
Improve the error reporting by converting from anyhow to thiserror. Anyhow is a convenience crate meant for applications which obscures error details in order to make it easier for application developers who are not concerned about error details at the current time to get code out. Crates should expose error details clearly and in a strongly-typed way to consuming applications so that those applications are able to either use those details to react properly or ignore them, as the application business needs dictate. Thiserror is a crate designed for this purpose, so it is a better fit for this crate.