### PR TITLE
Updating factbook.yaml to get factbook_compliant in Policy Engine

### DIFF
--- a/factbook.yaml
+++ b/factbook.yaml
@@ -4,6 +4,7 @@ spec:
   type: library
   lifecycle: production
   owner: ae@mdsol.com
+  experience: enablement
 metadata:
   json_schema: https://github.com/mdsol/platform-standards/tree/main/schemas/v1alpha1.schema.json
   name: mauth-core
@@ -15,3 +16,7 @@ metadata:
   people:
     - role: technical owner
       email: ykitamura@mdsol.com
+    - role: product owner
+      email: Not Found in Factbook
+  annotations:
+    product: Platform mauth


### PR DESCRIPTION
# Background:
 Policy Engine will be live soon and will block PRs for non factbook_compliant repos. 
# Changes Made: 
We gathered data from various sources. Please verify if the data in the PR is correct and if that is wrong, feel free to add a commit to correct the data.
Policy engine expects experience, product and team information to be present in the factbook.yaml file to mark the repo to be compliant. 
# Impact: 
This is just a METADATA file change which is consumed by DevOps central and there would be no other code change we are requesting for. Hence, looking forward to getting this PR reviewed and merged after verification and correction of the data. 
# Contact: 
Please reach out to [ops-dev-enablement](https://app.slack.com/channels/C08L42T5WJ2)