### PR TITLE
Pin dependencies for rsa, sha2, and spki to maintain compatibility with stable versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    # Keep these pinned until a stable rsa 0.10+ release is adopted.
+    ignore:
+      - dependency-name: "rsa"
+      - dependency-name: "sha2"
+      - dependency-name: "spki"
     groups:
       cargo:
         patterns:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ thiserror = "2"
 base64 = "0.22"
 hex = "0.4"
 lazy-regex = "3"
+# Keep these crypto dependencies on stable, compatible versions.
+# rsa 0.9 uses digest 0.10; moving to sha2 0.11 requires rsa 0.10, which is still RC.
 rsa = "0.9.0"
-regex = { version = "1", default_features = false, features = ["std"] }
+regex = { version = "1", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", features = ["oid"] }
 urlencoding = "2"
 spki = "0.7"


### PR DESCRIPTION
`cargo check` fails after upgrading `sha2` to `0.11`: https://github.com/mdsol/mauth-core/actions/runs/29965664808/job/89076482618?pr=48

<img width="1075" height="161" alt="Screenshot 2026-07-23 at 8 46 05" src="https://github.com/user-attachments/assets/27ee091f-4a9a-497c-b343-b49f132a3a04" />

also, addressing this warning:
> warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `regex` dependency)